### PR TITLE
delete new "declaration-property-value-no-unknown" rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,6 @@ module.exports = {
                 ]
             }
         ],
-        "declaration-property-value-no-unknown": true,
         "font-family-name-quotes": "always-where-recommended",
         "function-name-case": "lower",
         "function-url-quotes": "always",


### PR DESCRIPTION
nowa reguła niezbyt dobrze współgra z wykorzystaniem zmiennych w plikach scss
przykładowo taka składnia:
```
border-bottom: 3px solid $primary-color-black-mix-1;
```
uznawana jest za niepoprawną dopóki za zmienną nie podstawimy koloru
potencjalnie problem może występować przy każdej właściwości ze składnią typu shorthand z wykorzystaniem zmiennych